### PR TITLE
Update link.xml

### DIFF
--- a/Assets/_PackageRoot/Runtime/link.xml
+++ b/Assets/_PackageRoot/Runtime/link.xml
@@ -3,6 +3,10 @@
     <type fullname="*" preserve="all" />
   </assembly>
 
+  <assembly fullname="Microsoft.EntityFrameworkCore.Sqlite">
+    <type fullname="*" preserve="all" />
+  </assembly>
+
   <assembly fullname="Microsoft.EntityFrameworkCore.Relational">
     <type fullname="*" preserve="all" />
   </assembly>

--- a/Assets/_PackageRoot/package.json
+++ b/Assets/_PackageRoot/package.json
@@ -6,7 +6,7 @@
         "email": "ivan.d.murzak@gmail.com",
         "url": "https://github.com/IvanMurzak"
     },
-    "version": "0.1.0",
+    "version": "0.1.1",
     "unity": "2019.2",
     "description": "Bundle project that includes references on EntityFrameworkCore and SQLite set of packages to provide ready to go solution for Windows, MacOS, Android, iOS platforms.",
     "keywords": [


### PR DESCRIPTION
This pull request updates the `link.xml` file to include a new assembly for preservation during Unity's managed code stripping process.

Assembly additions:

* [`Assets/_PackageRoot/Runtime/link.xml`](diffhunk://#diff-07fb52d06794ae0f21328c024d34cee5c840e962a92f7cd9d4cb778abc57f3fdR6-R9): Added the `Microsoft.EntityFrameworkCore.Sqlite` assembly with all types preserved to ensure compatibility during code stripping.